### PR TITLE
add /tmp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM scratch
 
 COPY ./swarm /swarm
 COPY ./certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY ./tmp /tmp
 
 ENV SWARM_HOST :2375
 EXPOSE 2375


### PR DESCRIPTION
@aluzzardi mesos requires a tmp folder. it's either this on doing an mkdir in the mesos+swarm code.
What do you prefer ?
